### PR TITLE
Fixing change cfdoc integration to prefer script examples over tags #42

### DIFF
--- a/plugins/lookup.js
+++ b/plugins/lookup.js
@@ -95,11 +95,12 @@ module.exports = (function() {
 						const theoreticalMax = 2000; //rough guess at how many characters we get
 						const link = ' // http://cfdocs.org/' + term;
 						let msg = '`';
+						let syntax = result.script || result.syntax;
 
 						if (result.type === 'tag'){
-							msg += result.syntax + ' -- ' + result.description.replace(/\s+/g, ' ') + '`';
+							msg += syntax + ' -- ' + result.description.replace(/\s+/g, ' ') + '`';
 						}else{
-							msg += result.syntax + ' -- returns ' + (result.returns.length ? result.returns : ' nothing') + '`';
+							msg += syntax + ' -- returns ' + (result.returns.length ? result.returns : ' nothing') + '`';
 						}
 
 						let bufferRemaining = theoreticalMax - ( (bot.botName.length + 1) + link.length);


### PR DESCRIPTION
Added a variable to store the syntax in. Attempts to first retrieve the script style syntax. If that fails, it will grab what is stored in `syntax` in the result. It then concatenates that to the string that will be displayed in place of the standard `result.syntax` that it used before. Should address issue #42.
