### PR TITLE
🐳 Dockerize watney!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/*
 lib/config.user.json
 lib/watney.user.json
 bin/*
+redis-data/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:6.11.4-alpine
+
+# Create app directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# By copying in package.json and running npm install BEFORE
+# copying in the application code, the intermediate image this
+# step generates can be reused as long as the package.json hasn't
+# changed. Faster & less bandwidth used for builds!
+COPY ./package.json /usr/src/app/package.json
+COPY ./package-lock.json /usr/src/app/package-lock.json
+RUN npm install
+
+# We _MUST_ copy the source code into the container so that
+# the node process can start and the container can exist.
+# The reason we _also_ mount the volume is so that changes
+# on the host are immediately available in the container.
+COPY . /usr/src/app/
+
+# Start the giving node app
+CMD [ "npm", "start" ]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-up:
+up start:
 	docker-compose up -d
 	docker-compose logs -f
 
-down:
+down stop:
 	docker-compose down
 
 restart:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+up:
+	docker-compose up -d
+	docker-compose logs -f
+
+down:
+	docker-compose down
+
+restart:
+	docker-compose restart
+
+compile:
+	docker-compose up -d --build
+	docker-compose logs -f
+
+logs:
+	docker-compose logs -f
+

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ For customizing or extending @watney, see [dev-help](https://github.com/ryanguil
 
 Coming soon!
 
+### Starting Watney with Docker/Make
+
+The old school Make cli tool is used to make the syntax of various commands easier to remember and portable. docker-compose is used to orchestrate the two containers. Assuming you have Docker and Make available, here are the commands:
+
+- `make up` - starts watney and redis; creating docker images if this is the first time
+- `make compile` - same as `make up` but with a forced container recompile
+- `make down` - shut down both containers
+- `make logs` - start tailing the logs for both containers
+- `make restart` - restart both containers
+
+The redis container will store its data in an AOF (append-only filesystem) in `./redis-data`.
+
 ### The MIT License (MIT)
 
 Copyright (c) 2015 Ryan Guill, Adam Tuttle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+
+services:
+  bot:
+    container_name: watney_bot
+    restart: always
+    build: ./
+    external_links:
+    - redis:redis
+  redis:
+    container_name: watney_redis
+    restart: always
+    image: redis:alpine
+    command: redis-server --appendonly yes
+    volumes:
+    - ./redis-data:/data

--- a/lib/config.json
+++ b/lib/config.json
@@ -1,13 +1,13 @@
 {
-	"slackToken": ""
-	,"botName": "watney"
-	,"ignoreChannels": []
-	,"autoReconnect" : true
-	,"autoMark": true
-	,"testingChannel": "#bots"
-	,"redis_port": 6379
-	,"redis_host": ""
-	,"redis_auth_pass": ""
-	,"debug": true
-	,"maxHistoryPerChannel": 15000
+  "slackToken": "",
+  "botName": "watney",
+  "ignoreChannels": [],
+  "autoReconnect": true,
+  "autoMark": true,
+  "testingChannel": "#bots",
+  "redis_port": 6379,
+  "redis_host": "redis",
+  "redis_auth_pass": "",
+  "debug": true,
+  "maxHistoryPerChannel": 15000
 }


### PR DESCRIPTION
Resolve #50 (I think).

I apologize for the indentation change in `lib/config.json`. I've been trying out VSCode and it's forcing my json files to 2 spaces. Haven't figured out how to fix that yet. It also switched to comma-last instead of comma-first, which is not my preference, but we're standardizing on [prettier](https://github.com/prettier/prettier) at work and that's one of its opinions. Maybe something to consider for watney?

Anyway, I ran my fork of watney, hermes, in the cfml slack briefly tonight out of this docker setup. I think it meets the needs for now but let me know if you have any questions. 😎 🐳 