### PR TITLE
Possible fix for 'Private user info' issue

### DIFF
--- a/plugins/karma.js
+++ b/plugins/karma.js
@@ -113,7 +113,7 @@ module.exports = (function(){
 
 		let userKarma = getLeaderboard().find(o => o.handle === slackUser.name);
 
-		return channel.send('`' + bot.makeMention(user) + ' gives karma to ' + bot.makeMention(slackUser.id) +
+		return channel.send('`' + bot.makeMention(user) + ' gives karma to ' + bot.makeMention(slackUser) +
 			'. They now have ' + userKarma.value + ' karma. #' + userKarma.place + ' overall.`');
 	}
 

--- a/plugins/karma.js
+++ b/plugins/karma.js
@@ -113,7 +113,7 @@ module.exports = (function(){
 
 		let userKarma = getLeaderboard().find(o => o.handle === slackUser.name);
 
-		return channel.send('`' + bot.makeMention(user) + ' gives karma to ' + bot.makeMention(slackUser.name) +
+		return channel.send('`' + bot.makeMention(user) + ' gives karma to ' + bot.makeMention(slackUser.id) +
 			'. They now have ' + userKarma.value + ' karma. #' + userKarma.place + ' overall.`');
 	}
 


### PR DESCRIPTION
Passing the user to makeMention shows the name when giving Karma, I have tested on my own slack. I dont know if it replicates the old functionality exactly, but guessing it cant hurt

Issue seems to have arose from these changes
https://api.slack.com/changelog/2017-09-the-one-about-usernames

I initially passed id, but seems more in keeping with makeMention to pass the user as it does with the Karma giver, at the start of the message, which is not affected. Which is why there are 2 commits in this pull request